### PR TITLE
fix: release process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # ratchet:tibdex/github-app-token@v1.8.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Configure committer
         run: |
@@ -38,7 +45,7 @@ jobs:
           title: "chore(release): ${{ env.TAG }}"
           body: "Automated release of ${{ env.TAG }}"
           labels: auto-release
-          token: ${{ github.token }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Push new tag
         run: git push --follow-tags

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure committer
         run: |


### PR DESCRIPTION
GitHub prevents actions from triggering subsequent workflows to prevent abuse and infinite loop scenarios. 

Workarounds available: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs 

Opted to use a GitHub app as seems the best approach to use events already in place on workflows + have reasonable security posture.