### PR TITLE
Revert "fix: use token instead of deployment key"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           installation_id: ${{ secrets.APP_INSTALL_ID }}
-          token: ${{ steps.generate_token.outputs.token }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # ratchet:actions/checkout@v3
         with:


### PR DESCRIPTION
This reverts commit e6a75250b9ee0e37fda1f40628c0923cd7ce04d4.